### PR TITLE
Set eol to LF for modules folder, fix for windows os.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+modules/** eol=lf

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ One of these virtualization providers:
 Windows users require additionally
 
 * SSH provided by the Git package from http://msysgit.github.io
-* Ruby for Windows from http://rubyinstaller.org (add Ruby executables to PATH)
 
 You can use `init.sh` (Linux) and `init.bat` (Windows) to check the pre-requisites.
 

--- a/init.bat
+++ b/init.bat
@@ -3,20 +3,14 @@
 :: TODO: check for vagrant, virtualbox
 
 set git_found=0
-set ruby_found=0
 set ssh_found=0
 
 :: look for git, ruby, ssh
 for %%x in (git) do if not [%%~$PATH:x]==[] set git_found=1
-for %%x in (ruby) do if not [%%~$PATH:x]==[] set ruby_found=1
 for %%x in (ssh) do if not [%%~$PATH:x]==[] set ssh_found=1
 
 if %git_found%==0 (
   echo git executable not found in PATH. Please fix it!
-  EXIT /B 1
-)
-if %ruby_found%==0 (
-  echo ruby executable not found in PATH. Please fix it!
   EXIT /B 1
 )
 if %ssh_found%==0 (


### PR DESCRIPTION
Or after vagrant up i recieve this error:
```: No such file or directoryrror: /Stage[main]/Apache/Concat[/etc/httpd/conf/ports.conf]/Exec[concat_/etc/httpd/conf/ports.conf]: Could not evaluate: /usr/bin/env: ruby
==> g2i2.demo.icinga.org:
: No such file or directoryrror: /Stage[main]/Apache/Concat[/etc/httpd/conf/ports.conf]/Exec[concat_/etc/httpd/conf/ports.conf]: Failed to call refresh: /usr/bin/env: ruby
==> g2i2.demo.icinga.org:
: No such file or directoryrror: /Stage[main]/Apache/Concat[/etc/httpd/conf/ports.conf]/Exec[concat_/etc/httpd/conf/ports.conf]: /usr/bin/env: ruby
==> g2i2.demo.icinga.org:```

Becase on windows git clone change eol to CRLF an then puppet try to run modules on linux guest with windows eol. So some scripts doesn`t work.