### PR TITLE
rum yum clean before puppet to get rid of apparent stale yum metadata

### DIFF
--- a/icinga1x/Vagrantfile
+++ b/icinga1x/Vagrantfile
@@ -25,6 +25,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provider "virtualbox" do |vb|
     vb.customize ["modifyvm", :id, "--memory", "1024"]
   end
+  config.vm.provision :shell, :path => "manifests/init.sh"
   config.vm.provision :puppet do |puppet|
     puppet.module_path = "modules"
     puppet.manifests_path = "manifests"

--- a/icinga1x/manifests/init.sh
+++ b/icinga1x/manifests/init.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+yum -y clean all


### PR DESCRIPTION
Provisioning of the icinga1x box is broken because "yum install tomcat6" fails (apparently the box image contains some stale yum metadata that shouldn't be in there). It was working until two days ago or so.

```
$ vagrant up

==> default: Error: Execution of '/usr/bin/yum -d 0 -e 0 -y install tomcat6' returned 1: Error: failure: repodata/a187d1ec58638338d8dffb4015dee12a1e714b1701da7913201f7ef51a3df7c2-filelists.sqlite.bz2 from extras: [Errno 256] No more mirrors to try.
==> default:  You could try using --skip-broken to work around the problem
==> default:  You could try running: rpm -Va --nofiles --nodigest
==> default:
==> default: Error: /Stage[main]/Tomcat6/Package[tomcat6]/ensure: change from absent to present failed: Execution of '/usr/bin/yum -d 0 -e 0 -y install tomcat6' returned 1: Error: failure: repodata/a187d1ec58638338d8dffb4015dee12a1e714b1701da7913201f7ef51a3df7c2-filelists.sqlite.bz2 from extras: [Errno 256] No more mirrors to try.
==> default:  You could try using --skip-broken to work around the problem
==> default:  You could try running: rpm -Va --nofiles --nodigest
==> default:
==> default: Notice: /Stage[main]/Tomcat6/File[/etc/sysconfig/tomcat6]: Dependency Package[tomcat6] has failures: true
==> default: Warning: /Stage[main]/Tomcat6/File[/etc/sysconfig/tomcat6]: Skipping because of failed dependencies
.....
==> default: Error: Execution of '/usr/bin/yum -d 0 -e 0 -y install mysql-connector-java' returned 1: Error: failure: repodata/a187d1ec58638338d8dffb4015dee12a1e714b1701da7913201f7ef51a3df7c2-filelists.sqlite.bz2 from extras: [Errno 256] No more mirrors to try.
==> default:  You could try using --skip-broken to work around the problem
==> default:  You could try running: rpm -Va --nofiles --nodigest
==> default:
==> default: Error: /Stage[main]/Jasperserver/Package[mysql-connector-java]/ensure: change from absent to present failed: Execution of '/usr/bin/yum -d 0 -e 0 -y install mysql-connector-java' returned 1: Error: failure: repodata/a187d1ec58638338d8dffb4015dee12a1e714b1701da7913201f7ef51a3df7c2-filelists.sqlite.bz2 from extras: [Errno 256] No more mirrors to try.
==> default:  You could try using --skip-broken to work around the problem
==> default:  You could try running: rpm -Va --nofiles --nodigest
==> default:
==> default: Notice: /Stage[main]/Icinga-reports/Exec[install-tomcat-mysql-connector]: Dependency Package[tomcat6] has failures: true
.....
```

Issuing "yum clean all" before the puppet run resolves this. I'm using a separate shell provisioner; alternatively you could probably write an exec resource in puppet (and let Stage[main] depend on it). Fixing the image might be a cleaner solution, but anyway...