### PR TITLE
icinga2x: Add NagVis demo maps

### DIFF
--- a/icinga2x/manifests/default.pp
+++ b/icinga2x/manifests/default.pp
@@ -311,6 +311,8 @@ exec { 'feed-tts-comments-host':
 
 include nagvis
 
+icinga2::feature { 'livestatus': }
+
 icingaweb2::module { 'nagvis':
   builtin => false
 }

--- a/modules/nagvis/manifests/config.pp
+++ b/modules/nagvis/manifests/config.pp
@@ -20,6 +20,35 @@ class nagvis::config {
     content => template('nagvis/nagvis.ini.php.erb'),
   }
 
+  file { 'nagvis_geomap_locations':
+    name => '/usr/local/nagvis/etc/geomap/icinga2-locations.csv',
+    owner => apache,
+    group => apache,
+    mode => '0644',
+    content => template('nagvis/geomap/icinga2-locations.csv'),
+  }
+  file { 'nagvis_maps_overview':
+    name => '/usr/local/nagvis/etc/maps/demo-overview.cfg',
+    owner => apache,
+    group => apache,
+    mode => '0644',
+    content => template('nagvis/maps/demo-overview.cfg'),
+  }
+  file { 'nagvis_maps_groups':
+    name => '/usr/local/nagvis/etc/maps/demo-groups.cfg',
+    owner => apache,
+    group => apache,
+    mode => '0644',
+    content => template('nagvis/maps/demo-groups.cfg'),
+  }
+  file { 'nagvis_maps_geomap':
+    name => '/usr/local/nagvis/etc/maps/demo-geomap.cfg',
+    owner => apache,
+    group => apache,
+    mode => '0644',
+    content => template('nagvis/maps/demo-geomap.cfg'),
+  }
+
   # require our own fixed apache config
   file { 'nagvis_httpd_config':
     name => '/etc/httpd/conf.d/nagvis.conf',

--- a/modules/nagvis/manifests/params.pp
+++ b/modules/nagvis/manifests/params.pp
@@ -1,7 +1,7 @@
 
 class nagvis::params (
   $monitoring_type = 'icinga',
-  $nagvis_version = '1.8.5',
+  $nagvis_version = '1.9.2',
   $prefix = '/usr/local/nagvis',
   $http_user = 'apache',
   $http_group = 'apache',

--- a/modules/nagvis/templates/geomap/icinga2-locations.csv
+++ b/modules/nagvis/templates/geomap/icinga2-locations.csv
@@ -1,0 +1,2 @@
+map-server-san-francisco-0;Map San Francisco Server 0;37.774929;-122.419416
+map-server-los-angeles-0;Map Los Angeles Server 0;34.052234;-118.243685

--- a/modules/nagvis/templates/maps/demo-geomap.cfg
+++ b/modules/nagvis/templates/maps/demo-geomap.cfg
@@ -1,0 +1,12 @@
+define global {
+    sources=geomap
+    alias=Icinga 2 Geomap
+    parent_map=icinga2-overview
+    label_show=1
+    label_text=[name]
+    iconset=std_big
+    # Geomap specific parameters
+    source_file=icinga2-locations
+    width=1024
+    height=768
+}

--- a/modules/nagvis/templates/maps/demo-groups.cfg
+++ b/modules/nagvis/templates/maps/demo-groups.cfg
@@ -1,0 +1,33 @@
+define global {
+alias=Icinga 2 Groups
+# background_color=#0095bf
+label_show=1
+label_text=[name]
+iconset=std_big
+}
+
+# depends on sample config from icinga, nothing else
+define hostgroup {
+hostgroup_name=linux-servers
+x=200
+y=100
+}
+
+define hostgroup {
+hostgroup_name=windows-servers
+x=400
+y=100
+}
+
+
+define servicegroup {
+servicegroup_name=ping
+x=200
+y=300
+}
+
+define servicegroup {
+servicegroup_name=http
+x=400
+y=300
+}

--- a/modules/nagvis/templates/maps/demo-overview.cfg
+++ b/modules/nagvis/templates/maps/demo-overview.cfg
@@ -1,0 +1,23 @@
+define global {
+alias=Icinga 2 Overview
+iconset=std_big
+label_show=1
+label_border=transparent
+label_style=font-size:16px;font-weight:bold;color:#ffffff
+map_image=demo-overview.png
+background_color=#e8e8e8
+label_x=+46
+label_y=+3
+}
+
+define map {
+map_name=demo-groups
+x=60
+y=90
+}
+
+define map {
+map_name=demo-geomap
+x=60
+y=150
+}

--- a/modules/nagvis/templates/nagvis.ini.php.erb
+++ b/modules/nagvis/templates/nagvis.ini.php.erb
@@ -10,15 +10,18 @@ logonmodule="LogonIcingaweb2"
 htmlcgi = "/icingaweb2"
 
 [defaults]
+; Select a backend below
 backend="ndomy_1"
+
 urltarget="_top"
 hosturl="[htmlcgi]/monitoring/host/show?host=[host_name]"
 hostgroupurl="[htmlcgi]/monitoring/list/hostgroups?hostgroup_name=[hostgroup_name]"
 serviceurl="[htmlcgi]/monitoring/service/show?host=[host_name]&service=[service_description]"
-servicegroupurl="[htmlcgi]/monitoring/list/servicegroups?servicegroup=[servicegroup_name]"
+servicegroupurl="[htmlcgi]/monitoring/list/servicegroups?servicegroup_name=[servicegroup_name]"
 mapurl="[htmlcgi]/nagvis/show/map?map=[map_name]"
-headermenu="0"
+headermenu=0
 stylesheet="icingaweb-nagvis-integration.css"
+
 
 [backend_ndomy_1]
 backendtype="ndomy"
@@ -30,6 +33,12 @@ dbpass="icinga"
 dbprefix="icinga_"
 dbinstancename="default"
 ;maxtimewithoutupdate=180
+
+[backend_livestatus]
+backendtype="mklivestatus"
+socket="unix:/var/run/icinga2/cmd/livestatus"
+timeout=30
+
 
 [automap]
 [wui]


### PR DESCRIPTION
This replaces the old demo overview which was more or less useless.

- groups demo (also for Livestatus tests)
- geomap demo with a locations file (sfo and la)

Haven't found any better examples, NagVis isn't so easy to configure.

Bumped NagVis to 1.9.2 too.

The backend can be changed to use `livestatus` (Options - Manage Backends - Default Backend).
The livestatus feature in Icinga 2 has been re-enabled for tests.

Note: The Puppet module's code is rather hack-ish, once in a while
I'll either fix it, or remove the NagVis demo.

refs icinga/icinga2#5078
refs icinga/icinga2#5503