### PR TITLE
icinga2x-elastic: Listen on hostonly interface too

### DIFF
--- a/icinga2x-elastic/manifests/default.pp
+++ b/icinga2x-elastic/manifests/default.pp
@@ -256,7 +256,7 @@ class { 'elasticsearch':
 elasticsearch::instance { 'elastic-es':
   config => {
     'cluster.name' => 'elastic',
-    'network.host' => '127.0.0.1'
+    'network.host' => '127.0.0.1,192.168.33.7'
   }
 }->
 class { 'kibana':


### PR DESCRIPTION
This allows you to test-drive a host local Icinga 2
feature against the box itself.