### PR TITLE
php: Ensure compatibility with rh-php71

### DIFF
--- a/modules/profiles/manifests/icinga/icingaweb2.pp
+++ b/modules/profiles/manifests/icinga/icingaweb2.pp
@@ -91,7 +91,10 @@ class profiles::icinga::icingaweb2 (
   #  groups +> ['icingaweb2']
   #}
 
-
+  file { '/usr/local/bin/php':
+    ensure => link,
+    target => '/opt/rh/rh-php71/root/usr/bin/php',
+  } -> Class['php::composer::auto_update']
 
   package { [ 'scl-utils', 'centos-release-scl' ]:
     ensure => present,


### PR DESCRIPTION
So that the module does not fail:
```
==> icinga2a: Error: /usr/bin/env: php: No such file or directory
==> icinga2a:
==> icinga2a: Error: /Stage[main]/Php::Composer::Auto_update/Exec[update composer]/returns: change from notrun to 0 failed: /usr/bin/env: php: No such file or directory
```