### PR TITLE
Enable Icinga Web 2 doc module for developer icons

### DIFF
--- a/.puppet/modules/profiles/manifests/icinga/icingaweb2.pp
+++ b/.puppet/modules/profiles/manifests/icinga/icingaweb2.pp
@@ -134,6 +134,9 @@ class profiles::icinga::icingaweb2 (
     }
   }
   ->
+  class { '::icingaweb2::module::doc':
+  }
+  ->
   package { 'icingaweb2-selinux':
     ensure => latest,
   }


### PR DESCRIPTION
Requested by @nbuchwitz during his #icingacamp Berlin talk :-)