### PR TITLE
Fix portforwarding autocorrection in Vagrant

### DIFF
--- a/distributed/Vagrantfile
+++ b/distributed/Vagrantfile
@@ -36,7 +36,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       node_config.vm.box_url = options[:url] if options[:url]
       if options[:forwarded]
         options[:forwarded].each_pair do |guest, local|
-          node_config.vm.network "forwarded_port", guest: guest, host: local
+          node_config.vm.network "forwarded_port", guest: guest, host: local, auto_correct: true
         end
       end
 

--- a/elastic/Vagrantfile
+++ b/elastic/Vagrantfile
@@ -36,7 +36,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       node_config.vm.box_url = options[:url] if options[:url]
       if options[:forwarded]
         options[:forwarded].each_pair do |guest, local|
-          node_config.vm.network "forwarded_port", guest: guest, host: local
+          node_config.vm.network "forwarded_port", guest: guest, host: local, auto_correct: true
         end
       end
 

--- a/graylog/Vagrantfile
+++ b/graylog/Vagrantfile
@@ -36,7 +36,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       node_config.vm.box_url = options[:url] if options[:url]
       if options[:forwarded]
         options[:forwarded].each_pair do |guest, local|
-          node_config.vm.network "forwarded_port", guest: guest, host: local
+          node_config.vm.network "forwarded_port", guest: guest, host: local, auto_correct: true
         end
       end
 

--- a/influxdb/Vagrantfile
+++ b/influxdb/Vagrantfile
@@ -36,7 +36,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       node_config.vm.box_url = options[:url] if options[:url]
       if options[:forwarded]
         options[:forwarded].each_pair do |guest, local|
-          node_config.vm.network "forwarded_port", guest: guest, host: local
+          node_config.vm.network "forwarded_port", guest: guest, host: local, auto_correct: true
         end
       end
 

--- a/standalone/Vagrantfile
+++ b/standalone/Vagrantfile
@@ -36,7 +36,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       node_config.vm.box_url = options[:url] if options[:url]
       if options[:forwarded]
         options[:forwarded].each_pair do |guest, local|
-          node_config.vm.network "forwarded_port", guest: guest, host: local
+          node_config.vm.network "forwarded_port", guest: guest, host: local, auto_correct: true
         end
       end
 


### PR DESCRIPTION
These ports don't really serve a purpose here with
host only interfaces, but I'll keep them for the time
being, still with auto-correct enabled for now.