### PR TITLE
Remove restart of icinga2

### DIFF
--- a/.puppet/scripts/shell_provisioner_post.sh
+++ b/.puppet/scripts/shell_provisioner_post.sh
@@ -5,8 +5,3 @@ set -e
 if rpm -q "rh-php71-php-fpm" &>/dev/null; then
   systemctl restart rh-php71-php-fpm.service
 fi
-
-if rpm -q "icinga2-bin" &>/dev/null; then
-  # workaround for https://github.com/Icinga/icinga2/issues/6112
-  systemctl restart icinga2
-fi


### PR DESCRIPTION
As https://github.com/Icinga/icinga2/issues/6112 is fixed, the restart of icinga2 should no longer be necessary.