### PR TITLE
Icinga2: Add director-global zone

### DIFF
--- a/.puppet/modules/profiles/manifests/icinga/icinga2.pp
+++ b/.puppet/modules/profiles/manifests/icinga/icinga2.pp
@@ -116,6 +116,10 @@ class profiles::icinga::icinga2 (
     global => true,
   }
 
+  icinga2::object::zone { 'director-global':
+    global => true,
+  }
+
 
   # Features
   if (has_key($features, 'graphite')) {


### PR DESCRIPTION
This PR adds director global by default allowing users to start with the director more easily.

@pdorschner: We talked about this, now here is the PR.