### PR TITLE
Support vagrant-hostmanager

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ The required resources are automatically configured during the
 > OpenStack VMs are provisioned remotely in your cloud provider.
 > Please continue [here](doc/25-Openstack.md) for a full documentation.
 
+Optional:
+
+* [vagrant-hostmanager](https://github.com/devopsgroup-io/vagrant-hostmanager) >= 1.8.1
+
 ## Linux <a id="requirements-linux"></a>
 
 ### VirtualBox <a id="requirements-linux-virtualbox"></a>
@@ -424,6 +428,9 @@ nodes = {
 }
 ```
 
+If the `vagrant-hostmanager` plugin is installed an entry in `/etc/hosts` will be created to provide
+access by name.
+
 ## Configuration: Icinga Package Repository <a id="configuration-icinga-repo"></a>
 
 This requires you to edit the Hiera configuration tracked by Git. The setting below
@@ -569,7 +576,8 @@ Thanks to all [contributors](AUTHORS)! :)
 Each box uses a generic Vagrantfile to set the required resources for initial VM
 startup. The `Vagrantfile` includes the `Vagrantfile.nodes` file which defines
 VM specific settings. In addition to that, `tools/vagrant_helper.rb` loads all
-pre-defined functions for provider and provisioner instantiation.
+pre-defined functions for provider and provisioner instantiation. Furthermore it
+configures `vagrant-hostmanager` if the plugin is installed.
 
 The generic `shell_provisioner.sh` scripts ensure that all VM requirements are fulfilled
 and also takes care about installing Puppet which will be used as provisioner in the next

--- a/centos7-dev/Vagrantfile
+++ b/centos7-dev/Vagrantfile
@@ -32,5 +32,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
       provision_post(node_config, name, options)
     end
+
+    config_hostmanager(config)
   end
 end

--- a/distributed/Vagrantfile
+++ b/distributed/Vagrantfile
@@ -33,5 +33,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
       provision_post(node_config, name, options)
     end
+
+    config_hostmanager(config)
   end
 end

--- a/elastic/Vagrantfile
+++ b/elastic/Vagrantfile
@@ -32,5 +32,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
       provision_post(node_config, name, options)
     end
+
+    config_hostmanager(config)
   end
 end

--- a/graylog/Vagrantfile
+++ b/graylog/Vagrantfile
@@ -32,5 +32,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
       provision_post(node_config, name, options)
     end
+
+    config_hostmanager(config)
   end
 end

--- a/influxdb/Vagrantfile
+++ b/influxdb/Vagrantfile
@@ -32,5 +32,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
       provision_post(node_config, name, options)
     end
+
+    config_hostmanager(config)
   end
 end

--- a/standalone/Vagrantfile
+++ b/standalone/Vagrantfile
@@ -32,5 +32,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
       provision_post(node_config, name, options)
     end
+
+    config_hostmanager(config)
   end
 end

--- a/tools/vagrant_helper.rb
+++ b/tools/vagrant_helper.rb
@@ -171,3 +171,13 @@ def provision_post(node_config, name, options)
     echo "Navigate to http://#{options[:hostonly]}"
   SHELL
 end
+
+def config_hostmanager(config)
+      return unless Vagrant.has_plugin?('vagrant-hostmanager')
+
+      config.hostmanager.enabled = true
+      config.hostmanager.manage_host = true
+      config.hostmanager.manage_guest = false
+      config.hostmanager.ignore_private_ip = false
+      config.hostmanager.include_offline = true
+end


### PR DESCRIPTION
This adds support for the vagrant plugin which will if installed add host entries on the host for accessing the boxes via fqdn. 