### PR TITLE
simplify icingda-director service setup

### DIFF
--- a/.puppet/modules/profiles/manifests/icinga/icingaweb2.pp
+++ b/.puppet/modules/profiles/manifests/icinga/icingaweb2.pp
@@ -310,11 +310,9 @@ class profiles::icinga::icingaweb2 (
   }
   ->
   systemd::unit_file { 'icinga-director.service':
-    source => '/usr/share/icingaweb2/modules/director/contrib/systemd/icinga-director.service'
-  }
-  ~>
-  service { 'icinga-director':
-    ensure => 'running'
+    source => '/usr/share/icingaweb2/modules/director/contrib/systemd/icinga-director.service',
+    active => true,
+    enable => true,
   }
 
   ##########################################################


### PR DESCRIPTION
systemd::unit_file is able to manage the service for us, so we don't
need to explicitly declare a service resource.

Note: This not only starts the daemon (active = true), but it also puts
it into autostart (enable = true).